### PR TITLE
Fix `reportPrivateImportUsage` for VS Code

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -891,13 +891,13 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.39"
+version = "3.0.41"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "prompt_toolkit-3.0.39-py3-none-any.whl", hash = "sha256:9dffbe1d8acf91e3de75f3b544e4842382fc06c6babe903ac9acb74dc6e08d88"},
-    {file = "prompt_toolkit-3.0.39.tar.gz", hash = "sha256:04505ade687dc26dc4284b1ad19a83be2f2afe83e7a828ace0c72f3a1df72aac"},
+    {file = "prompt_toolkit-3.0.41-py3-none-any.whl", hash = "sha256:f36fe301fafb7470e86aaf90f036eef600a3210be4decf461a5b1ca8403d3cb2"},
+    {file = "prompt_toolkit-3.0.41.tar.gz", hash = "sha256:941367d97fc815548822aa26c2a269fdc4eb21e9ec05fc5d447cf09bad5d75f0"},
 ]
 
 [package.dependencies]
@@ -1424,13 +1424,13 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.6.0)", "pre-commit", "pytest (>=7.0,
 
 [[package]]
 name = "trio"
-version = "0.23.0"
+version = "0.23.1"
 description = "A friendly Python library for async concurrency and I/O"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "trio-0.23.0-py3-none-any.whl", hash = "sha256:213cd69a05962b1ba24d48caf08f7e7acf02bf1ebfac17c06d1248497f05795e"},
-    {file = "trio-0.23.0.tar.gz", hash = "sha256:662cfe10018018607a8e7ee191c274bcffbf9056be60b3ccb4f1790df98fc0a3"},
+    {file = "trio-0.23.1-py3-none-any.whl", hash = "sha256:bb4abb3f4af23f96679e7c8cdabb8b234520f2498550d2cf63ebfd95f2ce27fe"},
+    {file = "trio-0.23.1.tar.gz", hash = "sha256:16f89f7dcc8f7b9dcdec1fcd863e0c039af6d0f9a22f8dfd56f75d75ec73fd48"},
 ]
 
 [package.dependencies]
@@ -1469,13 +1469,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.7"
+version = "2.1.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
-    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
+    {file = "urllib3-2.1.0-py3-none-any.whl", hash = "sha256:55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3"},
+    {file = "urllib3-2.1.0.tar.gz", hash = "sha256:df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54"},
 ]
 
 [package.dependencies]
@@ -1483,7 +1483,6 @@ pysocks = {version = ">=1.5.6,<1.5.7 || >1.5.7,<2.0", optional = true, markers =
 
 [package.extras]
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
-secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
@@ -1509,13 +1508,13 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [[package]]
 name = "wcwidth"
-version = "0.2.9"
+version = "0.2.10"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = "*"
 files = [
-    {file = "wcwidth-0.2.9-py2.py3-none-any.whl", hash = "sha256:9a929bd8380f6cd9571a968a9c8f4353ca58d7cd812a4822bba831f8d685b223"},
-    {file = "wcwidth-0.2.9.tar.gz", hash = "sha256:a675d1a4a2d24ef67096a04b85b02deeecd8e226f57b5e3a72dbb9ed99d27da8"},
+    {file = "wcwidth-0.2.10-py2.py3-none-any.whl", hash = "sha256:aec5179002dd0f0d40c456026e74a729661c9d468e1ed64405e3a6c2176ca36f"},
+    {file = "wcwidth-0.2.10.tar.gz", hash = "sha256:390c7454101092a6a5e43baad8f83de615463af459201709556b6e4b1c861f97"},
 ]
 
 [[package]]
@@ -1535,4 +1534,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = ">= 3.11, < 4.0"
-content-hash = "5778ec480d7a9a4235a83fda1b3fdb7beb22e01b68d894655da394c9772f7564"
+content-hash = "f9a56698673c3d23f14671166b5452958ccb592c253315390ac17d5463deb4f4"

--- a/pomcorn/__init__.py
+++ b/pomcorn/__init__.py
@@ -1,4 +1,18 @@
-from .component import Component, ComponentWithBaseLocator, ListComponent
-from .element import Element, XPathElement
-from .page import Page
-from .web_view import WebView
+from pomcorn.component import (
+    Component,
+    ComponentWithBaseLocator,
+    ListComponent,
+)
+from pomcorn.element import Element, XPathElement
+from pomcorn.page import Page
+from pomcorn.web_view import WebView
+
+__all__ = (
+    "Component",
+    "ComponentWithBaseLocator",
+    "ListComponent",
+    "Element",
+    "XPathElement",
+    "Page",
+    "WebView",
+)

--- a/pomcorn/locators/__init__.py
+++ b/pomcorn/locators/__init__.py
@@ -1,5 +1,10 @@
-from .base_locators import Locator, TInitLocator, TLocator, XPathLocator
-from .xpath_locators import (
+from pomcorn.locators.base_locators import (
+    Locator,
+    TInitLocator,
+    TLocator,
+    XPathLocator,
+)
+from pomcorn.locators.xpath_locators import (
     ButtonWithTextLocator,
     ClassLocator,
     DataTestIdLocator,
@@ -10,4 +15,21 @@ from .xpath_locators import (
     PropertyLocator,
     TagNameLocator,
     TextAreaByLabelLocator,
+)
+
+__all__ = (
+    "Locator",
+    "TInitLocator",
+    "TLocator",
+    "XPathLocator",
+    "ButtonWithTextLocator",
+    "ClassLocator",
+    "DataTestIdLocator",
+    "ElementWithTextLocator",
+    "IdLocator",
+    "InputByLabelLocator",
+    "NameLocator",
+    "PropertyLocator",
+    "TagNameLocator",
+    "TextAreaByLabelLocator",
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,6 @@ python = ">= 3.11, < 4.0"
 # Python bindings for Selenium
 # https://selenium-python.readthedocs.io/index.html
 selenium = ">= 4.12"
-# Fixed version until fix of https://github.com/jorisroovers/gitlint/issues/535
-virtualenv = "20.24.5"
 
 [tool.poetry.group.dev.dependencies]
 # Improved REPL
@@ -53,6 +51,8 @@ ipython = ">= 8.14.0"
 # A framework for managing and maintaining multi-language pre-commit hooks.
 # https://pre-commit.com/
 pre-commit = ">= 3.3.3"
+# Fixed version until fix of https://github.com/jorisroovers/gitlint/issues/535
+virtualenv = "20.24.5"
 # Collection of invoke commands
 # https://github.com/saritasa-nest/saritasa-python-invocations
 saritasa-invocations = ">= 0.8"
@@ -113,17 +113,18 @@ known_pytest=[
     "_pytest",
     "xdist",
 ]
-known_page_object="page_object"
 sections=[
     "FUTURE",
     "STDLIB",
     "THIRDPARTY",
     "PYTEST",
-    "PAGE_OBJECT",
     "FIRSTPARTY",
     "LOCALFOLDER",
 ]
 include_trailing_comma=true
+# For sorting `__all__` sections
+# Off until the issue is fixed: https://github.com/PyCQA/isort/issues/2193
+# sort_reexports=true
 
 [tool.flake8]
 # F403: using wildcard imports (from … import *)


### PR DESCRIPTION
In VS Code `Pylance` when trying to import non-module names from `pomcorn` raises [reportPrivateImportUsage](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportPrivateImportUsage).

This doesn't interfere with the package, and `mypy` doesn't swear at it, but we lose the import hints described in the main [\_\_init\_\_.py](https://github.com/saritasa-nest/pomcorn/blob/main/pomcorn/__init__.py) file
![image](https://github.com/saritasa-nest/pomcorn/assets/61578484/ff44b14f-b9d4-47ed-a32f-150777ac3fbe)
and see the nasty underline:
![image](https://github.com/saritasa-nest/pomcorn/assets/61578484/7d398fc0-8058-4d9e-9c33-a8fdc8cdc318)

I found the following two solutions:

1. Add "private imports" to the `__all__` symbol as written in the [pyright docs](https://github.com/microsoft/pyright/blob/main/docs/typed-libraries.md#library-interface)
2. [Ignore this error](https://stackoverflow.com/questions/70735379/vscode-pylance-type-checking-does-not-recognize-re-imports/72336249#72336249) and use full path imports (like `import pomcorn.locators.xpath_locators as locators`)

I find it very convenient to use a short import, so I implemented the first solution.