### PR TITLE
Add small extensions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,8 +86,6 @@ Below is the code that opens ``PyPI.org``, searches for packages by name and pri
 packages to the terminal. The script contains all base classes contained in ``pomcorn``: **Page**,
 **ComponentWithBaseLocator**, **ListComponent** and **Element**.
 
-.. /* yaspeller ignore:start */
-
 .. code-block:: python
 
   from typing import Self
@@ -105,11 +103,11 @@ packages to the terminal. The script contains all base classes contained in ``po
       APP_ROOT = "https://pypi.org"
 
       def check_page_is_loaded(self) -> bool:
-          return self.init_element(locator=locators.TagNameLocator("main")).is_displayed
+          return self.init_element(locators.TagNameLocator("main")).is_displayed
 
       @property
       def search(self) -> Element[locators.XPathLocator]:
-          return self.init_element(locator=locators.IdLocator("search"))
+          return self.init_element(locators.IdLocator("search"))
 
 
   # Prepare components
@@ -158,8 +156,6 @@ packages to the terminal. The script contains all base classes contained in ``po
 
   search_page = SearchPage.open(webdriver=Chrome())
   print(search_page.find("saritasa").names)
-
-.. /* yaspeller ignore:end */
 
 For more information about package classes, you can read in `Object Hierarchy <https://pomcorn.readthedocs.io/en/latest/objects_hierarchy.html>`_
 and `Developer Interface <https://pomcorn.readthedocs.io/en/latest/developer_interface.html>`_.

--- a/demo/pages/base/base_page.py
+++ b/demo/pages/base/base_page.py
@@ -42,6 +42,9 @@ class PyPIPage(Page):
         # The Logo will be on all the pages of the application so we initialize
         # it in base page class.
         self.logo = self.init_element(
+            # The ``locator=`` keyword is optional here, but we recommend using
+            # it to be consistent with the method of the same name in
+            # ``ComponentWithBaseLocator``. Same with ``init_elements``.
             locator=locators.ClassLocator("site-header__logo"),
         )
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -3,6 +3,15 @@ Version history
 
 We follow `Semantic Versions <https://semver.org/>`_.
 
+0.4.0
+*******************************************************************************
+
+- Add ``|`` (or) operator for XPathLocators
+- Add ``Page.click_on_page`` method
+- Add recommendation for use keyword when specifying the ``locator`` argument
+  in ``init_element`` and ``init_elements`` methods whenever possible to be
+  consistent with the method of the same name in ``ComponentWithBaseLocator``
+
 0.3.1
 *******************************************************************************
 

--- a/pomcorn/locators/base_locators.py
+++ b/pomcorn/locators/base_locators.py
@@ -127,6 +127,21 @@ class XPathLocator(Locator):
         """Override `//` operator to implement nested XPath locators."""
         return XPathLocator(query=f"{self.query}//{other.related_query}")
 
+    def __or__(self, other: XPathLocator) -> XPathLocator:
+        r"""Override `|` operator to implement variant XPath locators.
+
+        Example:
+            span = XPathLocator("//span")
+            div = XPathLocator("//div")
+            img = XPathLocator("//img")
+
+            (span | div) // img == XPathLocator("(//span | //div)//img")
+
+            span | div // img == XPathLocator("(//span | //div//img)")
+
+        """
+        return XPathLocator(query=f"({self.query} | {other.query})")
+
     def extend_query(self, extra_query: str) -> XPathLocator:
         """Return new XPathLocator with extended query."""
         return XPathLocator(query=self.query + extra_query)

--- a/pomcorn/page.py
+++ b/pomcorn/page.py
@@ -3,6 +3,7 @@ from typing import Self
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.remote.webdriver import WebDriver
 
+from . import locators
 from .exceptions import PageDidNotLoadedError
 from .web_view import WebView
 
@@ -144,6 +145,15 @@ class Page(WebView):
         self.webdriver.get(
             self._get_full_relative_url(self.app_root, relative_url),
         )
+
+    def click_on_page(self):
+        """Click on page `html` tag.
+
+        Allows you to move focus away from an element, for example, if it
+        is currently unavailable for interaction.
+
+        """
+        self.init_element(locator=locators.TagNameLocator("html")).click()
 
     @staticmethod
     def _get_full_relative_url(app_root: str, relative_url: str) -> str:

--- a/pomcorn/web_view.py
+++ b/pomcorn/web_view.py
@@ -47,6 +47,10 @@ class WebView:
     def init_element(self, locator: TInitLocator) -> Element[TInitLocator]:
         """Shortcut for initializing Element instances.
 
+        Note: To be consistent with the method of the same name in
+        ``ComponentWithBaseLocator``, try to use keyword when specifying
+        the ``locator`` argument whenever possible.
+
         Args:
             locator: Instance of a class to locate the element in the browser.
 
@@ -60,6 +64,10 @@ class WebView:
         """Shortcut for initializing many Element instances via single locator.
 
         Note: Only supports Xpath locators.
+
+        Note: To be consistent with the method of the same name in
+        ``ComponentWithBaseLocator``, try to use keyword when specifying the
+        ``locator`` argument whenever possible.
 
         Args:
             locator: Instance of a class to locate the element in the browser.
@@ -88,9 +96,10 @@ class WebView:
 
         For example, there are multiple elements on the page that matches
         `XPathLocator("//a")`.
+
         This method return the set of locators like:
-        * `XPathLocator("//a[1]")`
-        * `XPathLocator("//a[2]")`
+        * `XPathLocator("(//a)[1]")`
+        * `XPathLocator("(//a)[2]")`
 
         Args:
             locator: Instance of a class to locate the element in the browser.


### PR DESCRIPTION
- Add ``|`` (or) operator for ``XPathLocators``
- Add ``Page.click_to_page`` method
- ~~Update ``WebView.init_element`` to be consistent with ``ComponentWithBaseLocator.init_element``~~

Update:

After discussion, we decided to revert `init_element` changes back to minimize code needed for simple cases. Instead, we added a recomendation to documentation that when using this method it is better to write `locator=` by default, but if it gets in the way in simple cases, it can be ignored.