### PR TITLE
Add descriptors for elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,10 @@ Below is the code that opens ``PyPI.org``, searches for packages by name and pri
 
       APP_ROOT = "https://pypi.org"
 
+      search = Element(locators.IdLocator("search"))
+
       def check_page_is_loaded(self) -> bool:
           return self.init_element(locators.TagNameLocator("main")).is_displayed
-
-      @property
-      def search(self) -> Element[locators.XPathLocator]:
-          return self.init_element(locators.IdLocator("search"))
 
 
   # Prepare components
@@ -96,10 +94,7 @@ Below is the code that opens ``PyPI.org``, searches for packages by name and pri
   class PackageList(ListComponent[Package, PyPIPage]):
 
       item_class = Package
-
-      @property
-      def base_item_locator(self) -> locators.XPathLocator:
-          return self.base_locator // locators.ClassLocator("snippet__name")
+      relative_item_locator = locators.ClassLocator("snippet__name")
 
       @property
       def names(self) -> list[str]:
@@ -135,6 +130,7 @@ Below is the code that opens ``PyPI.org``, searches for packages by name and pri
 
   search_page = SearchPage.open(webdriver=Chrome())
   print(search_page.find("saritasa").names)
+  search_page.webdriver.close()
 ```
 
 For more information about package classes, you can read in [Object Hierarchy](https://pomcorn.readthedocs.io/en/latest/objects_hierarchy.html) and [Developer Interface](https://pomcorn.readthedocs.io/en/latest/developer_interface.html).

--- a/demo/pages/common/navigation_bar.py
+++ b/demo/pages/common/navigation_bar.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pages import PyPIComponent, PyPIPage
+from pages import PyPIComponent
 
-from pomcorn import locators
+from pomcorn import Element, locators
 
 if TYPE_CHECKING:
     from pages.help_page import HelpPage
@@ -17,28 +17,16 @@ if TYPE_CHECKING:
 class Navbar(PyPIComponent):
     """Component representing navigation bar in the top of web application."""
 
-    def __init__(
-        self,
-        page: PyPIPage,
-        base_locator: locators.XPathLocator = locators.ClassLocator(
-            class_name="horizontal-menu",
-            # We specify `container` here because the page has several `nav`
-            # tags and several elements with a similar class name.
-            container="nav",
-        ),
-        # If you don't need to wait for the component to become visible during
-        # initialization, set `wait_until_visible` to `False`.
-        wait_until_visible: bool = True,
-    ):
-        super().__init__(page, base_locator, wait_until_visible)
-        self.help_button = self.init_element(
-            # Specifying the argument name is required here, because depending
-            # on the name `init_element` method can modify the passed locator.
-            relative_locator=locators.ElementWithTextLocator(
-                text="Help",
-                element="a",
-            ),
-        )
+    base_locator = locators.ClassLocator(
+        class_name="horizontal-menu",
+        # We specify `container` here because the page has several `nav`
+        # tags and several elements with a similar class name.
+        container="nav",
+    )
+
+    help_button = Element(
+        locator=locators.ElementWithTextLocator(text="Help", element="a"),
+    )
 
     def open_help(self) -> HelpPage:
         """Click on `Help` button and redirect to HelpPage."""

--- a/demo/pages/help_page.py
+++ b/demo/pages/help_page.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from pages.base import PyPIPage
 from selenium.webdriver.remote.webdriver import WebDriver
 
-from pomcorn import XPathElement, locators
+from pomcorn import Element, locators
 
 
 class HelpPage(PyPIPage):
     """Represent the help page."""
+
+    # Define element for title
+    title_element = Element(locators.ClassLocator("page-title"))
 
     @classmethod
     def open(
@@ -25,18 +28,10 @@ class HelpPage(PyPIPage):
         # user does.
         return IndexPage.open(webdriver, app_root=app_root).navbar.open_help()
 
-    @property
-    def title_element(self) -> XPathElement:
-        """Get the title element."""
-        return self.init_element(locators.ClassLocator("page-title"))
-
     def check_page_is_loaded(self) -> bool:
         """Return the check result that the page is loaded.
 
-        Return whether `main` tag and help page title element are displayed
-        or not.
+        Return whether help page title element are displayed or not.
 
         """
-        return (
-            super().check_page_is_loaded() and self.title_element.is_displayed
-        )
+        return self.title_element.is_displayed

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -17,6 +17,10 @@ Backwards incompatible changes in 0.7.0
 - Remove simple ``Component`` class
 - Rename ``ComponentWithBaseLocator`` to ``Component``
 
+- Rename ``Element`` class to ``PomcornElement``
+- Add descriptor ``Element`` to simplify adding element-attributes to **Pages**
+  and **Components**
+
 0.6.0
 *******************************************************************************
 

--- a/docs/descriptors.rst
+++ b/docs/descriptors.rst
@@ -1,0 +1,37 @@
+===============================================================================
+Descriptors
+===============================================================================
+
+``pomcorn`` now provides descriptor for **Elements**. This allows us to define
+elements as class attributes of a page or component. Example of usage:
+
+.. code-block:: python
+
+  from pomcorn import Element, Page, locators
+  from demo.pages.common.navigation_bar import Navbar
+
+  class PyPIPage(Page):
+
+      search_input = Element(locators.ClassLocator("search"))
+
+The descriptor takes a locator to locate element on page or inside component
+(then we need to pass ``is_relative_locator=true``) and creates a new instance
+of element the first time ``search_input`` attribute is accessed and caches it
+to return the cached value the next time.
+
+The cache is intended to avoid calling ``wait_until_visible`` multiple times in
+the initialization of the element.
+
+*******************************************************************************
+Element descriptor interfaces
+*******************************************************************************
+
+.. _Element:
+
+.. autoclass:: pomcorn.descriptors.Element
+   :members:
+
+.. automodule:: pomcorn.descriptors.element
+   :members:
+   :special-members: __init__
+   :exclude-members: Element

--- a/docs/developer_interface.rst
+++ b/docs/developer_interface.rst
@@ -16,14 +16,19 @@ Page
 .. automodule:: pomcorn.page
     :members:
 
-Element
-*******************************************************************************
-
-.. automodule:: pomcorn.element
-   :members:
-
 Components
 *******************************************************************************
 
 .. automodule:: pomcorn.component
+   :members:
+
+
+PomcornElement
+*******************************************************************************
+
+.. note::
+  This class is returned when the ``Element`` descriptor or the
+  ``init_element/init_elements`` methods of the page or components are used.
+
+.. automodule:: pomcorn.element
    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ Documentation
    objects_hierarchy
    developer_interface
    locators
+   descriptors
    waits_conditions
    development
    contributing

--- a/docs/objects_hierarchy.rst
+++ b/docs/objects_hierarchy.rst
@@ -63,8 +63,14 @@ the component body to interact with it.
 **ListComponent** - It's a class, descendant of **Component**, with implemented methods for work
 with list-like components: ``all``, ``count`` and ``get_item_by_text``.
 
-Element class
+PomcornElement class
 *******************************************************************************
 
 A smallest part of page(component). It can be a button, link, or just some text. In general, you can
 imagine that this is an html tag.
+
+
+.. note::
+    The class is rarely initiated in its pure form, so we added descriptors for easy definition of
+    element-attributes (see :ref:`descriptors<Descriptors>`), and within **Page** and **Component**
+    classes, an element can be defined using the :ref:`self.init_element<WebView>` method.

--- a/poetry.lock
+++ b/poetry.lock
@@ -831,13 +831,13 @@ ptyprocess = ">=0.5"
 
 [[package]]
 name = "platformdirs"
-version = "4.2.1"
+version = "4.2.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.2.1-py3-none-any.whl", hash = "sha256:17d5a1161b3fd67b390023cb2d3b026bbd40abde6fdb052dfbd3a29c3ba22ee1"},
-    {file = "platformdirs-4.2.1.tar.gz", hash = "sha256:031cd18d4ec63ec53e82dceaac0417d218a6863f7745dfcc9efe7793b7039bdf"},
+    {file = "platformdirs-4.2.2-py3-none-any.whl", hash = "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee"},
+    {file = "platformdirs-4.2.2.tar.gz", hash = "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"},
 ]
 
 [package.extras]
@@ -1416,13 +1416,13 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,
 
 [[package]]
 name = "trio"
-version = "0.25.0"
+version = "0.25.1"
 description = "A friendly Python library for async concurrency and I/O"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "trio-0.25.0-py3-none-any.whl", hash = "sha256:e6458efe29cc543e557a91e614e2b51710eba2961669329ce9c862d50c6e8e81"},
-    {file = "trio-0.25.0.tar.gz", hash = "sha256:9b41f5993ad2c0e5f62d0acca320ec657fdb6b2a2c22b8c7aed6caf154475c4e"},
+    {file = "trio-0.25.1-py3-none-any.whl", hash = "sha256:e42617ba091e7b2e50c899052e83a3c403101841de925187f61e7b7eaebdf3fb"},
+    {file = "trio-0.25.1.tar.gz", hash = "sha256:9f5314f014ea3af489e77b001861c535005c3858d38ec46b6b071ebfa339d7fb"},
 ]
 
 [package.dependencies]

--- a/pomcorn/__init__.py
+++ b/pomcorn/__init__.py
@@ -1,5 +1,6 @@
 from pomcorn.component import Component, ListComponent
-from pomcorn.element import Element, XPathElement
+from pomcorn.descriptors import Element
+from pomcorn.element import XPathElement
 from pomcorn.page import Page
 from pomcorn.web_view import WebView
 

--- a/pomcorn/component.py
+++ b/pomcorn/component.py
@@ -31,9 +31,9 @@ class Component(Generic[TPage], WebView):
 
         Args:
             page: An instance of the page that uses this component.
-            base_locator: Instance of a class to locate the element in
-                the browser. Used in relative element initialization methods
-                and visibility waits. You also can specify it as attribute.
+            base_locator: Instance of a class to locate the component in the
+                browser. Used in relative element initialization methods and
+                visibility waits. You also can specify it as attribute.
             wait_until_visible: Whether to wait for the component to become
                 visible before completing initialization or not.
 

--- a/pomcorn/descriptors/__init__.py
+++ b/pomcorn/descriptors/__init__.py
@@ -1,0 +1,3 @@
+from pomcorn.descriptors.element import Element
+
+__all__ = ("Element",)

--- a/pomcorn/descriptors/element.py
+++ b/pomcorn/descriptors/element.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NoReturn
+
+from pomcorn import locators
+
+if TYPE_CHECKING:
+    from pomcorn import WebView, XPathElement
+
+
+class Element:
+    """Descriptor for init `PomcornElement` as attribute by locator.
+
+    .. code-block:: python
+
+        # Example
+        from pomcorn import Page, Element
+
+        class MainPage(Page):
+            title_element = Element(locators.ClassLocator("page-title"))
+
+    """
+
+    cache_attribute_name = "cached_elements"
+
+    def __init__(
+        self,
+        locator: locators.XPathLocator,
+        is_relative_locator: bool = True,
+    ) -> None:
+        """Initialize descriptor.
+
+        Args:
+            locator: Instance of a class to locate the element in
+                the browser.
+            is_relative_locator: Whether add parent ``base_locator`` to the
+                current descriptors's `base_locator` or not. If descriptor is
+                used for ``Page``, the value of this argument will not be used.
+
+        """
+        self.is_relative_locator = is_relative_locator
+        self.locator = locator
+
+    def __set_name__(self, _owner: type, name: str) -> None:
+        """Save attribute name for which descriptor is created."""
+        self.attribute_name = name
+
+    def __get__(
+        self,
+        instance: WebView | None,
+        _type: type[WebView],
+    ) -> XPathElement:
+        """Get element with stored locator."""
+        if not instance:
+            raise AttributeError("This descriptor is for instances only!")
+        return self.prepare_element(instance)
+
+    def prepare_element(self, instance: WebView) -> XPathElement:
+        """Init and cache element in instance.
+
+        Initiate element only once, and then store it in an instance and
+        return it each subsequent time. This is to avoid calling
+        `wait_until_visible` multiple times in the init of component.
+
+        If the instance doesn't already have an attribute to store cache, it
+        will be set.
+
+        If descriptor is used for ``Component`` and
+        ``self.is_relative_locator=True``, element will be found by sum of
+        ``base_locator`` of that component and passed locator of descriptor.
+
+        If descriptor is used for instance of ``Page``, then ``base_locator``
+        is not needed, since element will be searched across the entire page,
+        not within some component.
+
+        """
+        if not getattr(instance, self.cache_attribute_name, None):
+            setattr(instance, self.cache_attribute_name, {})
+
+        cache = getattr(instance, self.cache_attribute_name, {})
+        if cached_element := cache.get(self.attribute_name):
+            return cached_element
+
+        from pomcorn import Component
+
+        if self.is_relative_locator and isinstance(instance, Component):
+            self.locator = instance.base_locator // self.locator
+
+        element = instance.init_element(locator=self.locator)
+        cache[self.attribute_name] = element
+
+        return element
+
+    def __set__(self, *args, **kwargs) -> NoReturn:
+        raise ValueError("You can't reset an element attribute value!")

--- a/pomcorn/element.py
+++ b/pomcorn/element.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from pomcorn.web_view import WebView
 
 
-class Element(Generic[locators.TLocator]):
+class PomcornElement(Generic[locators.TLocator]):
     """The class to represent a simple element (tag) on the page.
 
     Contains methods for the interaction with an element on the browser page.
@@ -306,7 +306,7 @@ class Element(Generic[locators.TLocator]):
 
     def drag_and_drop(
         self,
-        target: Element[locators.TLocator],
+        target: PomcornElement[locators.TLocator],
         only_visible: bool = True,
     ):
         """Drag and drop page object on target object.
@@ -380,4 +380,4 @@ class Element(Generic[locators.TLocator]):
         )
 
 
-XPathElement = Element[locators.XPathLocator]
+XPathElement = PomcornElement[locators.XPathLocator]

--- a/pomcorn/waits_conditions.py
+++ b/pomcorn/waits_conditions.py
@@ -13,7 +13,7 @@ from selenium.webdriver.support.expected_conditions import (
 
 from pomcorn.locators.base_locators import TLocator
 
-from .element import Element
+from .element import PomcornElement
 
 
 def url_not_matches(pattern: str) -> Callable[[WebDriver], bool]:
@@ -26,7 +26,7 @@ def url_not_matches(pattern: str) -> Callable[[WebDriver], bool]:
 
 
 def text_in_element_changes(
-    element: Element[TLocator] | TLocator,
+    element: PomcornElement[TLocator] | TLocator,
     old_text: str,
 ) -> Callable[[WebDriver], bool]:
     """Represent `wait condition` to check that text doesn't match old text.
@@ -40,7 +40,7 @@ def text_in_element_changes(
     def check_the_match(driver: WebDriver) -> bool:
         target = element
 
-        if isinstance(target, Element):
+        if isinstance(target, PomcornElement):
             return old_text != target.get_text()
 
         return old_text != driver.find_element(*target).text
@@ -49,14 +49,14 @@ def text_in_element_changes(
 
 
 def element_not_exists_in_dom(
-    element: Element[TLocator] | TLocator,
+    element: PomcornElement[TLocator] | TLocator,
 ) -> Callable[[WebDriver], bool]:
     """Represent `wait condition` to check that element not exists in DOM."""
 
     def check_the_match(driver: WebDriver) -> bool:
         target = element
 
-        if isinstance(target, Element):
+        if isinstance(target, PomcornElement):
             return not target.exists_in_dom
 
         try:

--- a/pomcorn/web_view.py
+++ b/pomcorn/web_view.py
@@ -7,7 +7,7 @@ from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
 
-from pomcorn.element import Element, XPathElement
+from pomcorn.element import PomcornElement, XPathElement
 
 from . import exceptions, locators, waits_conditions
 from .locators.base_locators import TInitLocator
@@ -44,7 +44,10 @@ class WebView:
             poll_frequency=poll_frequency,
         )
 
-    def init_element(self, locator: TInitLocator) -> Element[TInitLocator]:
+    def init_element(
+        self,
+        locator: TInitLocator,
+    ) -> PomcornElement[TInitLocator]:
         """Shortcut for initializing Element instances.
 
         Note: To be consistent with the method of the same name in
@@ -55,7 +58,7 @@ class WebView:
             locator: Instance of a class to locate the element in the browser.
 
         """
-        return Element(self, locator=locator)
+        return PomcornElement(web_view=self, locator=locator)
 
     def init_elements(
         self,
@@ -317,7 +320,7 @@ class WebView:
 
     def wait_until_not_exists_in_dom(
         self,
-        element: Element[locators.TLocator] | locators.TLocator,
+        element: PomcornElement[locators.TLocator] | locators.TLocator,
     ):
         """Wait until element ceases to exist in DOM.
 


### PR DESCRIPTION
Add descriptor classes for init elements as page or component attributes. This will allow us to initiate them every time we access an attribute and reduce the amount of code.

P.S. Descriptors for components will be prepared in next PR