### PR TITLE
Improve item class getting

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -3,6 +3,11 @@ Version history
 
 We follow `Semantic Versions <https://semver.org/>`_.
 
+0.8.2 (29.11.24)
+*******************************************************************************
+- Add ability to specify ``TypeAlias`` as ``_item class`` and use
+  ``ListComponent`` as a parameterized type
+
 0.8.1 (25.11.24)
 *******************************************************************************
 - Improve getting ``item class`` from first ``ListComponent`` generic variable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pomcorn"
-version = "0.8.1"
+version = "0.8.2"
 description = "Base implementation of Page Object Model"
 authors = [
   "Saritasa <pypi@saritasa.com>",

--- a/tests/list_component/test_item_class.py
+++ b/tests/list_component/test_item_class.py
@@ -1,4 +1,4 @@
-from typing import Generic, TypeVar
+from typing import Generic, TypeAlias, TypeVar
 
 import pytest
 
@@ -105,3 +105,34 @@ def test_set_item_class_with_extra_generic_variable(fake_page: Page) -> None:
     # Ensure that `List.item_class` has correct type
     list_cls = List(fake_page)
     assert list_cls._item_class is ItemClass
+
+
+def test_set_item_class_without_inheritance(fake_page: Page) -> None:
+    """Check that item_class will be correct in not inherited class."""
+
+    class BaseList(Generic[TItem, TPage], ListComponent[TItem, TPage]):
+        """Base list component without specified Generic variables."""
+
+        base_locator = locators.XPathLocator("html")  # required
+        relative_item_locator = locators.XPathLocator("body")  # required
+        wait_until_visible = lambda _: True  # to not wait anything
+
+    # Prepare base list component without specified Generic variables
+    list_cls = BaseList[ItemClass, Page](fake_page)
+    # Ensure that `InheritedList.item_class` has correct type
+    assert list_cls._item_class is ItemClass
+
+
+# Type alias for check that ItemClass can be also a TypeAlias
+TypeAliasItemClass: TypeAlias = Component[Page]
+
+
+def test_item_class_can_be_type_alias(fake_page: Page) -> None:
+    """Check that item_class can be a type alias based on ``Component``."""
+
+    class List(ListComponent[TypeAliasItemClass, Page]):
+        base_locator = locators.XPathLocator("html")  # required
+        wait_until_visible = lambda _: True  # to not wait anything
+
+    list_cls = List(fake_page)
+    assert list_cls._item_class is TypeAliasItemClass


### PR DESCRIPTION
After the previous pomcorn 0.8.1 update, we encountered two issues:

* TypeAlias passed in first generic parametter don't pass `is_valid_item_class` check
* We could not use `ListComponent` as a parameterized type
   Example:
   ```python
   class List[ListComponent[TItemClass, TPage]]:...
   list_component = List[ItemClass, Page]
    ```

In this commit, we improved getting `_item_class` for a parameterized `ListComponent`
and added support for TypeAlias in `is_valid_item_class` + added tests for these cases.