### PR TITLE
Add quotes escaper method

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -3,6 +3,13 @@ Version history
 
 We follow `Semantic Versions <https://semver.org/>`_.
 
+0.8.4 (30.01.25)
+*******************************************************************************
+- Add escaping single and double quotes in the: ``ElementWithTextLocator``,
+  ``InputInLabelLocator``, ``InputByLabelLocator``, ``TextAreaByLabelLocator``.
+- Add escaping single and double quotes in the ``get_item_by_text`` method of
+  the ``ListComponent``
+
 0.8.3 (20.12.24)
 *******************************************************************************
 - Rename ``__parameters__`` in ``ListComponent`` to ``__generic__parameters``

--- a/pomcorn/component.py
+++ b/pomcorn/component.py
@@ -352,8 +352,9 @@ class ListComponent(Generic[ListItemType, TPage], Component[TPage]):
     def get_item_by_text(self, text: str) -> ListItemType:
         """Get list item by text."""
         locator = self.base_item_locator.extend_query(
-            extra_query=f"[contains(.,"
-            f" {self.base_item_locator._escape_quotes(text)})]",
+            extra_query=(
+                f"[contains(., {self.base_item_locator._escape_quotes(text)})]"
+            ),
         )
         return self._item_class(page=self.page, base_locator=locator)
 

--- a/pomcorn/component.py
+++ b/pomcorn/component.py
@@ -352,7 +352,8 @@ class ListComponent(Generic[ListItemType, TPage], Component[TPage]):
     def get_item_by_text(self, text: str) -> ListItemType:
         """Get list item by text."""
         locator = self.base_item_locator.extend_query(
-            extra_query=f"[contains(.,'{text}')]",
+            extra_query=f"[contains(.,"
+            f" {self.base_item_locator._escape_quotes(text)})]",
         )
         return self._item_class(page=self.page, base_locator=locator)
 

--- a/pomcorn/locators/base_locators.py
+++ b/pomcorn/locators/base_locators.py
@@ -156,8 +156,8 @@ class XPathLocator(Locator):
         """Return whether query of current locator is empty or not."""
         return bool(self.related_query)
 
-    @staticmethod
-    def _escape_quotes(text: str) -> str:
+    @classmethod
+    def _escape_quotes(cls, text: str) -> str:
         """Escape single and double quotes in given text for use in locators. # noqa: D202, E501.
 
         This method is useful when locating elements
@@ -175,22 +175,22 @@ class XPathLocator(Locator):
 
         """
 
-        if ('"' not in text and "'" not in text) or (not text):
+        if not text or ('"' not in text and "'" not in text):
             return f'"{text}"'
 
         escaped_parts = []
         buffer = ""  # Temporary storage for normal characters
 
         for char in text:
-            if char in ('"', "'"):
-                if buffer:
-                    escaped_parts.append(f'"{buffer}"')
-                    buffer = ""
-                escaped_parts.append(
-                    "'" + char + "'" if char == '"' else '"' + char + '"',
-                )
-            else:
+            if char not in ('"', "'"):
                 buffer += char
+                continue
+            if buffer:
+                escaped_parts.append(f'"{buffer}"')
+                buffer = ""
+            escaped_parts.append(
+                "'" + char + "'" if char == '"' else '"' + char + '"',
+            )
 
         if buffer:
             escaped_parts.append(f'"{buffer}"')

--- a/pomcorn/locators/xpath_locators.py
+++ b/pomcorn/locators/xpath_locators.py
@@ -243,8 +243,10 @@ class InputByLabelLocator(XPathLocator):
     def __init__(self, label: str):
         """Init XPathLocator."""
         super().__init__(
-            query=f"//label[contains(.,"
-            f" {self._escape_quotes(label)})]/following-sibling::input",
+            query=(
+                f"//label[contains(., {self._escape_quotes(label)})]"
+                "/following-sibling::input"
+            ),
         )
 
 
@@ -260,6 +262,8 @@ class TextAreaByLabelLocator(XPathLocator):
     def __init__(self, label: str):
         """Init XPathLocator."""
         super().__init__(
-            query="//*[label[contains(text(),"
-            f" {self._escape_quotes(label)})]]/textarea",
+            query=(
+                "//*[label[contains(text(), "
+                f"{self._escape_quotes(label)})]]/textarea"
+            ),
         )

--- a/pomcorn/locators/xpath_locators.py
+++ b/pomcorn/locators/xpath_locators.py
@@ -140,8 +140,8 @@ class ElementWithTextLocator(XPathLocator):
                 partial match of the value.
 
         """
-        exact_query = f'//{element}[./text()="{text}"]'
-        partial_query = f'//{element}[contains(.,"{text}")]'
+        exact_query = f"//{element}[./text()={self._escape_quotes(text)}]"
+        partial_query = f"//{element}[contains(.,{self._escape_quotes(text)})]"
 
         super().__init__(query=exact_query if exact else partial_query)
 
@@ -219,7 +219,7 @@ class InputInLabelLocator(XPathLocator):
     def __init__(self, label: str):
         """Init XPathLocator."""
         super().__init__(
-            query=f'//label[contains(., "{label}")]//input',
+            query=f"//label[contains(., {self._escape_quotes(label)})]//input",
         )
 
 
@@ -243,7 +243,8 @@ class InputByLabelLocator(XPathLocator):
     def __init__(self, label: str):
         """Init XPathLocator."""
         super().__init__(
-            query=f'//label[contains(., "{label}")]/following-sibling::input',
+            query=f"//label[contains(.,"
+            f" {self._escape_quotes(label)})]/following-sibling::input",
         )
 
 
@@ -259,5 +260,6 @@ class TextAreaByLabelLocator(XPathLocator):
     def __init__(self, label: str):
         """Init XPathLocator."""
         super().__init__(
-            query=f'//*[label[contains(text(), "{label}")]]/textarea',
+            query="//*[label[contains(text(),"
+            f" {self._escape_quotes(label)})]]/textarea",
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pomcorn"
-version = "0.8.3"
+version = "0.8.4"
 description = "Base implementation of Page Object Model"
 authors = [
   "Saritasa <pypi@saritasa.com>",

--- a/tests/locators/test_quote_escaper.py
+++ b/tests/locators/test_quote_escaper.py
@@ -1,0 +1,51 @@
+from pomcorn.locators.base_locators import XPathLocator
+
+
+def test_empty_string():
+    """Test that an empty string returned as wrapped empty string."""
+    assert XPathLocator._escape_quotes("") == '""'
+
+
+def test_no_quotes():
+    """Test that a string without quotes returned as wrapped passed text."""
+    assert XPathLocator._escape_quotes("Hello World") == '"Hello World"'
+
+
+def test_single_quote():
+    """Test escaping a string with a single quote."""
+    assert (
+        XPathLocator._escape_quotes("He's tall")
+        == 'concat("He", "\'", "s tall")'
+    )
+
+
+def test_double_quote():
+    """Test escaping a string with a double quote."""
+    assert (
+        XPathLocator._escape_quotes('She said "Hello"')
+        == 'concat("She said ", \'"\', "Hello", \'"\')'
+    )
+
+
+def test_both_single_and_double_quotes():
+    """Test escaping a string with both single and double quotes."""
+    assert (
+        XPathLocator._escape_quotes("He's 6'2\" tall")
+        == 'concat("He", "\'", "s 6", "\'", "2", \'"\', " tall")'
+    )
+
+
+def test_string_starts_with_quote():
+    """Test escaping a string that starts with a quote."""
+    assert XPathLocator._escape_quotes('"Start') == 'concat(\'"\', "Start")'
+
+
+def test_string_ends_with_quote():
+    """Test escaping a string that ends with a quote."""
+    assert XPathLocator._escape_quotes('End"') == 'concat("End", \'"\')'
+
+
+def test_string_with_only_quotes():
+    """Test escaping a string that contains only quotes."""
+    assert XPathLocator._escape_quotes('""') == "concat('\"', '\"')"
+    assert XPathLocator._escape_quotes("''") == 'concat("\'", "\'")'


### PR DESCRIPTION
Looks like for now there is some issue with pomcorn XpathLocators.

For example if I want to create a locator 
```python
locators.ElementWithTextLocator(
        text="He is choosing beetwen \"pancakes\" and 'waffles'", exact=True
    )
```
I'll get this query:
```
//*[./text()="He is choosing beetwen "pancakes" and 'waffles'"]
```
but it won't work
![image](https://github.com/user-attachments/assets/4d1b6913-2542-4152-b61b-8a15cd7ec829)


Current implementation can handle this cases and we get
```
//*[./text()=concat("He is choosing between ", '"', "pancakes", '"', " and ", "'", "waffles", "'")]
```
![image](https://github.com/user-attachments/assets/16236dc2-c60a-43aa-97ef-73461c3e0a5b)

