### PR TITLE
Add support str queries to locator div operations

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -3,6 +3,11 @@ Version history
 
 We follow `Semantic Versions <https://semver.org/>`_.
 
+
+0.9.3 (16.05.25)
+*******************************************************************************
+- Extend `/` and `//` operations to support combining `XPathLocator` with raw `str` queries.
+
 0.9.2 (07.05.25)
 *******************************************************************************
 - Fix mistake with \`CONTROL\` and \`COMMAND\` in \`PomcornElement.clear\`

--- a/pomcorn/locators/base_locators.py
+++ b/pomcorn/locators/base_locators.py
@@ -124,7 +124,7 @@ class XPathLocator(Locator):
         self.related_query = query.lstrip(self.divider)
         super().__init__(by=By.XPATH, query=query)
 
-    def __truediv__(self, other: XPathLocator) -> XPathLocator:
+    def __truediv__(self, other: XPathLocator | str) -> XPathLocator:
         """Override `/` operator to implement following XPath locators.
 
         "/" used to select the nearest children of the current node.
@@ -132,7 +132,7 @@ class XPathLocator(Locator):
         """
         return self.prepare_relative_locator(other=other, separator="/")
 
-    def __floordiv__(self, other: XPathLocator) -> XPathLocator:
+    def __floordiv__(self, other: XPathLocator | str) -> XPathLocator:
         """Override `//` operator to implement nested XPath locators.
 
         "//" used to select all descendants (children, grandchildren,
@@ -261,7 +261,7 @@ class XPathLocator(Locator):
 
     def prepare_relative_locator(
         self,
-        other: XPathLocator,
+        other: XPathLocator | str,
         separator: Literal["/", "//"] = "/",
     ) -> XPathLocator:
         """Prepare relative locator base on queries of two locators.
@@ -270,7 +270,7 @@ class XPathLocator(Locator):
         return only the filled one.
 
         Args:
-            other: Child locator object.
+            other: Child locator object or str locator query.
             separator: Literal which will placed between locators queries - "/"
                 used to select nearest children of current node and "//" used
                 to select all descendants (children, grandchildren,
@@ -289,6 +289,8 @@ class XPathLocator(Locator):
             #   (//li)[3] -> valid
             #   //(//li)[3] -> invalid
             related_query = f"//{self.related_query}"
+
+        other = XPathLocator(other) if isinstance(other, str) else other
 
         locator = XPathLocator(
             query=f"{related_query}{separator}{other.related_query}",

--- a/tests/locators/test_prepare_relative_locator.py
+++ b/tests/locators/test_prepare_relative_locator.py
@@ -1,0 +1,72 @@
+import pytest
+
+from pomcorn.locators.base_locators import XPathLocator
+
+
+@pytest.mark.parametrize(
+    argnames=["base_locator", "child_locator", "operator", "expected_xpath"],
+    argvalues=[
+        [XPathLocator("//div"), XPathLocator("/span"), "/", "//div/span"],
+        [XPathLocator("//div"), XPathLocator("//span"), "//", "//div//span"],
+        [XPathLocator("//ul/li"), XPathLocator("//a"), "/", "//ul/li/a"],
+        [
+            XPathLocator("(//li)[2]"),
+            XPathLocator("//button"),
+            "/",
+            "(//li)[2]/button",
+        ],
+        [
+            XPathLocator("(//li)[2]"),
+            XPathLocator("/button"),
+            "//",
+            "(//li)[2]//button",
+        ],
+        [XPathLocator(""), XPathLocator("/span"), "/", "/span"],
+        [XPathLocator("//div"), XPathLocator(""), "/", "//div"],
+    ],
+)
+def test_combining_xpath_locators(
+    base_locator: XPathLocator,
+    child_locator: XPathLocator,
+    operator: str,
+    expected_xpath: str,
+) -> None:
+    """Test combining two XPathLocator instances with `/` or `//`."""
+    result = (
+        base_locator / child_locator
+        if operator == "/"
+        else base_locator // child_locator
+    )
+    assert str(result) == expected_xpath
+
+
+@pytest.mark.parametrize(
+    argnames=["base_locator", "raw_suffix", "operator", "expected_xpath"],
+    argvalues=[
+        [XPathLocator("//div"), "//span", "/", "//div/span"],
+        [XPathLocator("//section"), "/a[@href]", "//", "//section//a[@href]"],
+    ],
+)
+def test_combining_with_raw_string_suffix(
+    base_locator: XPathLocator,
+    raw_suffix: str,
+    operator: str,
+    expected_xpath: str,
+) -> None:
+    """Test combining an XPathLocator with a raw string."""
+    result = (
+        base_locator / raw_suffix
+        if operator == "/"
+        else base_locator // raw_suffix
+    )
+    assert str(result) == expected_xpath
+
+
+def test_combining_empty_locators_raises_error() -> None:
+    """Test that combining two empty XPathLocators raises ValueError."""
+    first_locator = XPathLocator("")
+    second_locator = XPathLocator("")
+    with pytest.raises(ValueError, match="Both of locators have empty query"):
+        _ = first_locator / second_locator
+    with pytest.raises(ValueError, match="Both of locators have empty query"):
+        _ = first_locator // second_locator


### PR DESCRIPTION
Extend `/` and `//` operations to support combining `XPathLocator` with raw `str` queries.