### PR TITLE
Refactor `is_visible` logic in `_get_elements` and ``_get_element`  

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -3,6 +3,10 @@ Version history
 
 We follow `Semantic Versions <https://semver.org/>`_.
 
+0.9.4 (20.05.25)
+*******************************************************************************
+- Refactor `only_visible` logic in `_get_elements` and `_get_element` methods.
+
 
 0.9.3 (16.05.25)
 *******************************************************************************

--- a/pomcorn/web_view.py
+++ b/pomcorn/web_view.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver import ActionChains
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.remote.webelement import WebElement
@@ -145,9 +146,19 @@ class WebView:
                 counted.
 
         """
+        elements = self.webdriver.find_elements(*locator)
         if only_visible:
-            self.wait_until_locator_visible(locator=locator)
-        return self.webdriver.find_element(*locator)
+            elements = [
+                element for element in elements if element.is_displayed()
+            ]
+
+        if not elements:
+            raise NoSuchElementException(
+                f"No {'visible ' if only_visible else ''}elements"
+                f"found for locator: {locator}",
+            )
+
+        return elements[0]
 
     def _get_elements(
         self,
@@ -164,9 +175,19 @@ class WebView:
                 counted.
 
         """
+        elements = self.webdriver.find_elements(*locator)
         if only_visible:
-            self.wait_until_locator_visible(locator=locator)
-        return self.webdriver.find_elements(*locator)
+            elements = [
+                element for element in elements if element.is_displayed()
+            ]
+
+        if not elements:
+            raise NoSuchElementException(
+                f"No {'visible ' if only_visible else ''}elements"
+                f"found for locator: {locator}",
+            )
+
+        return elements
 
     def wait_until_url_contains(self, url: str):
         """Wait until browser's url contains input url.


### PR DESCRIPTION
According to docs of the `_get_elements` and `_get_element` methods 
```
            only_visible: Flag for viewing visible elements. If this is `True`
                (default), then this method will only get visible elements,
                otherwise all the elements (including not visible) will be
                counted.
```
If `only_visible` is passed, they should return only visible elements, but current implementation just wait until needed element is visible.
To handle only visible elements, we have to find every element wtih selenium's `find_elements` and filter by only displayed ones