### PR TITLE
Extend PomcornElement.click arguments

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -3,10 +3,18 @@ Version history
 
 We follow `Semantic Versions <https://semver.org/>`_.
 
-0.10.3 ()
+0.10.3 (06.04.26)
 *******************************************************************************
-- Extend `DataTestIdLocator` arguments with `exact` parameter to specify
-  whether to use exact match or contains match for `data-testid` attribute.
+- Extend ``DataTestIdLocator`` arguments with ``exact`` parameter to specify
+  whether to use exact match or contains match for ``data-testid`` attribute.
+- Extend ``PomcornElement.click()`` arguments with ``center_element`` parameter
+  to specify whether to scroll to element before click.
+
+  By default, webdriver scrolls to element before clicking if the element container
+  not in screen space or behind of ``header/footer`` elements, but in some cases element
+  can be inside screen space but overlapped by another element (e.g. by custom header/footer
+  that made using ``div`` tags) and at that case we might need to use pomcorn custom scroll
+  method which scrolling to element until it will be in center of screen.
 
 0.10.2 (24.11.25)
 *******************************************************************************

--- a/pomcorn/element.py
+++ b/pomcorn/element.py
@@ -328,6 +328,7 @@ class PomcornElement(Generic[locators.TLocator]):
         self,
         only_visible: bool = True,
         wait_until_clickable: bool = True,
+        center_element: bool = False,
     ):
         """Click on element.
 
@@ -336,10 +337,19 @@ class PomcornElement(Generic[locators.TLocator]):
                 (default), then this method will only get visible elements.
             wait_until_clickable: Wait until the element is clickable before
                 clicking, or not (default `True`).
+            center_element: Scroll the page until the element is in
+                the center, or not scroll (default `False`).
+
+        By default, webdriver scrolls to the element before clicking if the
+        element is not in viewport or is behind overlays (header/footer tags).
+        If the element is in viewport but overlapped, set center_element
+        to True to scroll until element is in the center of the screen.
 
         """
         if wait_until_clickable:
             self.wait_until_clickable()
+        if center_element:
+            self.scroll_to(only_visible=only_visible)
         self.get_element(only_visible=only_visible).click()
 
     def drag_and_drop(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pomcorn"
-version = "0.10.2"
+version = "0.10.3"
 description = "Base implementation of Page Object Model"
 authors = [
   "Saritasa <pypi@saritasa.com>",


### PR DESCRIPTION
Extend ``PomcornElement.click()`` arguments with ``scroll_to`` parameter to specify
whether to scroll to element before click.

By default, ``webdriver`` scrolls to the element before clicking if the
element is not in viewport or is behind overlays (header/footer tags).
If the element is visible but overlapped, set ``scroll_to`` to True to
scroll it to the center of the screen.